### PR TITLE
fix StudentTest and TeacherTest

### DIFF
--- a/src/test/java/sk/stuba/fei/uim/vsa/pr1/StudentTest.java
+++ b/src/test/java/sk/stuba/fei/uim/vsa/pr1/StudentTest.java
@@ -140,7 +140,7 @@ public class StudentTest {
             student = thesisService.updateStudent(student);
             assertNotNull(student);
             assertEquals(randomSetStringForTesting, getFieldValue(student, stringField, String.class));
-            student = thesisService.getStudent(Student01.aisId);
+            student = thesisService.getStudent(getEntityId(student, studentIdField));
             assertNotNull(student);
             assertEquals(randomSetStringForTesting, getFieldValue(student, stringField, String.class));
             assertNotEquals(originalStringValue, getFieldValue(student, stringField, String.class));

--- a/src/test/java/sk/stuba/fei/uim/vsa/pr1/TeacherTest.java
+++ b/src/test/java/sk/stuba/fei/uim/vsa/pr1/TeacherTest.java
@@ -140,7 +140,7 @@ public class TeacherTest {
             teacher = thesisService.updateTeacher(teacher);
             assertNotNull(teacher);
             assertEquals(randomSetStringForTesting, getFieldValue(teacher, stringField, String.class));
-            teacher = thesisService.getTeacher(Teacher01.aisId);
+            teacher = thesisService.getTeacher(getEntityId(teacher, teacherIdField));
             assertNotNull(teacher);
             assertEquals(randomSetStringForTesting, getFieldValue(teacher, stringField, String.class));
             assertNotEquals(originalStringValue, getFieldValue(teacher, stringField, String.class));


### PR DESCRIPTION
1. V teste na update teacher a update student sa v getStudent a getTeacher dava aisId. 
2. Nefunguje to v pripade, ze primary key studenta a ucitela nie je aisId ale generovane Id (v zadani bolo povolene mat ako primary key aj nieco ine ako aisId)
3. V gete som instanciu dostala pomocou getEntityId(student, studentIdField) nie pomocou aisId.
4. Dva testy padaju lebo thesisService.getStudent(Student01.aisId) a thesisService.getTeacher(Teacher01.aisId) vracaju null.